### PR TITLE
FEA-5 : ExpenseController Updated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/AppLidra.Server/Controllers/ExpenseController.cs
+++ b/AppLidra.Server/Controllers/ExpenseController.cs
@@ -1,21 +1,123 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using AppLidra.Server.Data;
 using AppLidra.Shared.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace AppLidra.Server.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class ExpenseController : ControllerBase
+[Authorize]
+public class ExpenseController(JsonDataStore store) : ControllerBase
 {
-    [HttpGet("{projectId}")]
-    public async Task<IActionResult> GetExpenses(int projectId)
+    JsonDataStore _store = store;
+
+    [HttpGet("{expenseId}")]
+    public IActionResult GetExpenses(int expenseId)
     {
-        // get expenses of a project
-        return Ok();
+        Expense expenses = _store.Expenses.Where(e => e.Id == expenseId).First();
+        return Ok(expenses);
     }
 
     [HttpPost]
-    public async Task<IActionResult> AddExpense(Expense expense)
+    public IActionResult AddExpense([FromBody] ExpenseModel expenseModel)
     {
-        // add an expense to the database
-        return Ok();
+        int userId = int.Parse(User.Claims.First(c => c.Type == ClaimTypes.NameIdentifier).Value);
+
+        User? user = _store.Users.FirstOrDefault(u => u.Id == userId);
+        if (user == null)
+            return NotFound("User not found");
+
+        Project? project = _store.Projects.FirstOrDefault(p => p.Id == expenseModel.ProjectId);
+        if (project == null)
+            return NotFound("Project not found");
+
+        bool hasRights = project.Collaborators.Contains(user.UserName);
+
+        if (!hasRights)
+            return NotFound("User not a collaborator");
+
+        for (int i = 0; i < expenseModel.Shares.Count; i++)
+        {
+            User? shareHolder = _store.Users.FirstOrDefault(u => u.Id == userId);
+            if (shareHolder == null)
+                return NotFound("ShareHolder not found");
+
+            bool isCollaborator = project.Collaborators.Contains(shareHolder.UserName);
+            if (!isCollaborator)
+                return NotFound("ShareHolder is not a collaborator");
+        }
+
+        int id = _store.Expenses.Count != 0 ? _store.Expenses.Max(e => e.Id) + 1 : 1;
+        Expense expense = new(id, expenseModel.Name, expenseModel.Amount, expenseModel.Date, expenseModel.ProjectId, expenseModel.Shares, user.UserName);
+
+        _store.Expenses.Add(expense);
+        _store.SaveChanges();
+
+        return Ok(expense);
+    }
+
+    [HttpPut("{expenseId}")]
+    public IActionResult UpdateExpense(int expenseId, [FromBody] Expense updatedExpense)
+    {
+        int userId = int.Parse(User.Claims.First(c => c.Type == ClaimTypes.NameIdentifier).Value);
+
+        User? user = _store.Users.FirstOrDefault(u => u.Id == userId);
+        if (user == null)
+            return NotFound("User not found");
+
+        Expense? expense = _store.Expenses.FirstOrDefault(e => e.Id == expenseId);
+        if (expense == null)
+            return NotFound("Expense not found");
+
+        Project? project = _store.Projects.FirstOrDefault(p => p.Id == expense.ProjectId);
+        if (project == null)
+            return NotFound("Project not found");
+
+        bool hasRights = project.Collaborators.Contains(user.UserName);
+
+        if (!hasRights)
+            return NotFound("User not a collaborator");
+
+        expense.Name = updatedExpense.Name;
+        expense.Author = updatedExpense.Author;
+        expense.Amount = updatedExpense.Amount;
+        expense.Date = updatedExpense.Date;
+        expense.Shares = updatedExpense.Shares;
+
+        _store.SaveChanges();
+
+        return Ok(expense);
+    }
+
+    [HttpDelete("{expenseId}")]
+    public IActionResult DeleteExpense(int expenseId)
+    {
+        int userId = int.Parse(User.Claims.First(c => c.Type == ClaimTypes.NameIdentifier).Value);
+
+        User? user = _store.Users.FirstOrDefault(u => u.Id == userId);
+        if (user == null)
+            return NotFound("User not found");
+
+        Expense? expense = _store.Expenses.FirstOrDefault(e => e.Id == expenseId);
+        if (expense == null)
+            return NotFound("Expense not found");
+
+        Project? project = _store.Projects.FirstOrDefault(p => p.Id == expense.ProjectId);
+        if (project == null)
+            return NotFound("Project not found");
+
+        bool hasRights = project.Collaborators.Contains(user.UserName);
+
+        if (!hasRights)
+            return NotFound("User not a collaborator");
+
+
+        _store.Expenses.Remove(expense);
+
+        _store.SaveChanges();
+
+        return Ok("Expense deleted successfully");
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to the `ExpenseController` in the `AppLidra.Server` project, focusing on enhancing the functionality and security of expense management. Additionally, a minor configuration change was made to the `.gitattributes` file.

Enhancements to expense management and security:

* [`AppLidra.Server/Controllers/ExpenseController.cs`](diffhunk://#diff-9b11e181b6d5c38033538268644c39d9898e9ddc2197b09d9bc683102c8394a5L1-R121): Added authorization to the `ExpenseController` by using the `[Authorize]` attribute and updated the constructor to accept a `JsonDataStore` parameter.
* [`AppLidra.Server/Controllers/ExpenseController.cs`](diffhunk://#diff-9b11e181b6d5c38033538268644c39d9898e9ddc2197b09d9bc683102c8394a5L1-R121): Implemented detailed logic in the `AddExpense` method to validate user and project existence, check collaborator rights, and add a new expense to the store.
* [`AppLidra.Server/Controllers/ExpenseController.cs`](diffhunk://#diff-9b11e181b6d5c38033538268644c39d9898e9ddc2197b09d9bc683102c8394a5L1-R121): Added `UpdateExpense` method to allow updating of an existing expense, including validation of user rights and updating expense details.
* [`AppLidra.Server/Controllers/ExpenseController.cs`](diffhunk://#diff-9b11e181b6d5c38033538268644c39d9898e9ddc2197b09d9bc683102c8394a5L1-R121): Added `DeleteExpense` method to handle the deletion of an expense, including validation of user rights and removal of the expense from the store.

Configuration update:

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1): Configured all text files to use LF line endings.