### PR TITLE
FEA-10 : Set up API communication

### DIFF
--- a/AppLidra.Client/Handlers/AuthorizationMessageHandler.cs
+++ b/AppLidra.Client/Handlers/AuthorizationMessageHandler.cs
@@ -1,0 +1,27 @@
+﻿using Blazored.LocalStorage;
+using System.Net.Http.Headers;
+
+namespace AppLidra.Client.Services;
+public class AuthorizationMessageHandler : DelegatingHandler
+{
+    private readonly ILocalStorageService _localStorage;
+
+    public AuthorizationMessageHandler(ILocalStorageService localStorage)
+    {
+        _localStorage = localStorage;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var token = await _localStorage.GetItemAsync<string>("authToken");
+
+        if (!string.IsNullOrEmpty(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            // Dans AuthorizationMessageHandler
+            Console.WriteLine($"Token being used: {token?.Substring(0, 20)}...");
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/AppLidra.Client/Handlers/HttpClientAuthorizationExtensions.cs
+++ b/AppLidra.Client/Handlers/HttpClientAuthorizationExtensions.cs
@@ -1,0 +1,21 @@
+﻿using AppLidra.Client.Services;
+namespace AppLidra.Client.Handlers;
+public static class HttpClientAuthorizationExtensions
+{
+    public static void AddAuthorizationHandler(this IServiceCollection services)
+    {
+        services.AddScoped<AuthorizationMessageHandler>();
+        services.AddScoped(sp =>
+        {
+            var handler = sp.GetRequiredService<AuthorizationMessageHandler>();
+            handler.InnerHandler = new HttpClientHandler();
+
+            var client = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://localhost:44354/")
+            };
+
+            return client;
+        });
+    }
+}

--- a/AppLidra.Client/Program.cs
+++ b/AppLidra.Client/Program.cs
@@ -1,4 +1,7 @@
 using AppLidra.Client;
+using AppLidra.Client.Services;
+using AppLidra.Client.Handlers;
+using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
@@ -6,6 +9,9 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddAuthorizationHandler();
+builder.Services.AddBlazoredLocalStorage();
+
+
 
 await builder.Build().RunAsync();

--- a/AppLidra.Client/Properties/launchSettings.json
+++ b/AppLidra.Client/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:39061",
-      "sslPort": 44353
+      "applicationUrl": "http://localhost:37609",
+      "sslPort": 44305
     }
   },
   "profiles": {
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "http://localhost:5019",
+      "applicationUrl": "http://localhost:5231",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:7019;http://localhost:5019",
+      "applicationUrl": "https://localhost:7255;http://localhost:5231",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
This pull request introduces several significant changes to the `AppLidra.Client` project, primarily focusing on adding authorization handling and updating launch settings. The most important changes include the creation of an `AuthorizationMessageHandler`, the addition of an extension method for adding this handler to the service collection, and updates to the program initialization and launch settings.

Authorization handling:

* [`AppLidra.Client/Handlers/AuthorizationMessageHandler.cs`](diffhunk://#diff-88fa50c1fd85383bb718281d1c1785ba0c903b34eef378065bff56f309a1f6bbR1-R27): Created a new `AuthorizationMessageHandler` class that retrieves an authorization token from local storage and adds it to the request headers.
* [`AppLidra.Client/Handlers/HttpClientAuthorizationExtensions.cs`](diffhunk://#diff-52fb2bed2128d46040760f31b7f88fa8a966b23844ff9ec69df7744f4aeb7382R1-R21): Added an extension method to configure the `AuthorizationMessageHandler` and register it with the service collection.

Program initialization:

* [`AppLidra.Client/Program.cs`](diffhunk://#diff-da4af536fd242e63b585ee523567d94069fafe48ef063b49ffd4018e28b0c3ddR2-R15): Updated the program initialization to use the new `AuthorizationMessageHandler` and added Blazored Local Storage service.

Launch settings:

* [`AppLidra.Client/Properties/launchSettings.json`](diffhunk://#diff-0fd30279db973b530a3a5cbca3a2af4ff07ae31c49a79d691f5089a90b2f64f4L7-R8): Updated the `applicationUrl` and `sslPort` values for different profiles to new port numbers. [[1]](diffhunk://#diff-0fd30279db973b530a3a5cbca3a2af4ff07ae31c49a79d691f5089a90b2f64f4L7-R8) [[2]](diffhunk://#diff-0fd30279db973b530a3a5cbca3a2af4ff07ae31c49a79d691f5089a90b2f64f4L17-R17) [[3]](diffhunk://#diff-0fd30279db973b530a3a5cbca3a2af4ff07ae31c49a79d691f5089a90b2f64f4L27-R27)

Related to #10 .
Closes #10 .